### PR TITLE
Add --storage option

### DIFF
--- a/ngshare/ngshare.py
+++ b/ngshare/ngshare.py
@@ -702,7 +702,8 @@ def main():
     parser.add_argument('--debug', action='store_true', help='enable debug')
     parser.add_argument('--database', help='database url',
                         default='sqlite:////srv/ngshare/ngshare.db')
-    parser.add_argument('--storage', help='path to store files')
+    parser.add_argument('--storage', help='path to store files',
+                        default='/tmp/ngshare/')
     args = parser.parse_args()
     if args.jupyterhub_api_url is not None:
         os.environ['JUPYTERHUB_API_URL'] = args.jupyterhub_api_url

--- a/ngshare/ngshare.py
+++ b/ngshare/ngshare.py
@@ -702,6 +702,7 @@ def main():
     parser.add_argument('--debug', action='store_true', help='enable debug')
     parser.add_argument('--database', help='database url',
                         default='sqlite:////srv/ngshare/ngshare.db')
+    parser.add_argument('--storage', help='path to store files')
     args = parser.parse_args()
     if args.jupyterhub_api_url is not None:
         os.environ['JUPYTERHUB_API_URL'] = args.jupyterhub_api_url

--- a/ngshare/vngshare.py
+++ b/ngshare/vngshare.py
@@ -38,6 +38,7 @@ def main():
                         default='sqlite:////tmp/ngshare.db')
     parser.add_argument('--host', help='bind hostname', default='127.0.0.1')
     parser.add_argument('--port', help='bind port', type=int, default=12121)
+    parser.add_argument('--storage', help='path to store files')
     args = parser.parse_args()
 
     app = MyApplication(args.prefix, args.database, debug=not args.no_debug)

--- a/ngshare/vngshare.py
+++ b/ngshare/vngshare.py
@@ -38,7 +38,8 @@ def main():
                         default='sqlite:////tmp/ngshare.db')
     parser.add_argument('--host', help='bind hostname', default='127.0.0.1')
     parser.add_argument('--port', help='bind port', type=int, default=12121)
-    parser.add_argument('--storage', help='path to store files')
+    parser.add_argument('--storage', help='path to store files',
+                        default='/tmp/ngshare/')
     args = parser.parse_args()
 
     app = MyApplication(args.prefix, args.database, debug=not args.no_debug)
@@ -49,6 +50,7 @@ def main():
 
     print('Starting vngshare (Vserver-like Notebook Grader Share)')
     print('Database file is %s' % repr(args.database))
+    print('Storage directory is %s' % repr(args.storage))
     print('Please go to http://%s:%d/api/' % (args.host, args.port))
     IOLoop.current().start()
 


### PR DESCRIPTION
Please use `python3 ngshare.py --storage /` to specify somewhere for ngshare to storage files. 

Currently only the cmd option is added. 