### PR TITLE
Add /healthz endpoint

### DIFF
--- a/docs/user_guide/extra.rst
+++ b/docs/user_guide/extra.rst
@@ -39,3 +39,8 @@ Initialize with test data
 
 Initialize database with some pre-defined test data. Only available when debug mode is on. 
 
+Health endpoint
+-------------
+``GET /healthz``
+
+This always returns a single JSON object with `{"success": true}`. It can be used as a liveness probe to ensure ngshare is up and running.

--- a/helmchart/ngshare/templates/deployment.yaml
+++ b/helmchart/ngshare/templates/deployment.yaml
@@ -34,11 +34,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/ngshare/ngshare.py
+++ b/ngshare/ngshare.py
@@ -887,10 +887,10 @@ class NotFoundHandler(RequestHandler):
 
 
 class HealthCheckHandler(RequestHandler):
-    'Health check handler on /healthz, for k8s'
+    '/healthz'
 
     def get(self):
-        "Returns a 200 to indicate we're alive"
+        "Health check endpoint for k8s. Returns a 200 to indicate we're alive"
         self.write(json.dumps({'success': True}))
         return
 

--- a/ngshare/ngshare.py
+++ b/ngshare/ngshare.py
@@ -885,6 +885,13 @@ class NotFoundHandler(RequestHandler):
         self.write(json.dumps(dict(os.environ), indent=1, sort_keys=True))
         self.write('\n' + self.request.uri + '\n' + self.request.path + '\n')
 
+class HealthCheckHandler(RequestHandler):
+    'Health check handler on /healthz, for k8s'
+
+    def get(self):
+        "Returns a 200 to indicate we're alive"
+        self.write(json.dumps({'success': True}))
+        return
 
 class MyApplication(Application):
     'Custom application for ngshare'
@@ -898,6 +905,10 @@ class MyApplication(Application):
         admin=(),
         autoreload=True,
     ):
+
+        if prefix.startswith('/healthz/'):
+            raise ValueError("API prefix may not start with /healthz/")
+
         handlers = [
             (prefix, HomePage),
             (prefix + r'(favicon\.ico)', Static),
@@ -922,6 +933,7 @@ class MyApplication(Application):
                 UploadDownloadFeedback,
             ),
             (prefix + 'initialize-Data6ase', InitDatabase),
+            ('/healthz', HealthCheckHandler),
         ]
         handlers.append((r'.*', NotFoundHandler))
         super(MyApplication, self).__init__(

--- a/ngshare/ngshare.py
+++ b/ngshare/ngshare.py
@@ -885,6 +885,7 @@ class NotFoundHandler(RequestHandler):
         self.write(json.dumps(dict(os.environ), indent=1, sort_keys=True))
         self.write('\n' + self.request.uri + '\n' + self.request.path + '\n')
 
+
 class HealthCheckHandler(RequestHandler):
     'Health check handler on /healthz, for k8s'
 
@@ -892,6 +893,7 @@ class HealthCheckHandler(RequestHandler):
         "Returns a 200 to indicate we're alive"
         self.write(json.dumps({'success': True}))
         return
+
 
 class MyApplication(Application):
     'Custom application for ngshare'

--- a/ngshare/test_ngshare.py
+++ b/ngshare/test_ngshare.py
@@ -76,6 +76,7 @@ def assert_success(url, data=None, params=None, method='GET'):
     assert resp['success'] == True
     return resp
 
+
 @pytest.mark.gen_test
 def test_health(http_client, base_url):
     'Test /healthz endpoint'
@@ -83,11 +84,13 @@ def test_health(http_client, base_url):
     assert response.code == 200
     assert json.loads(response.body)['success']
 
+
 @pytest.mark.gen_test
 def test_api_endpoint_conflict(http_client, base_url):
     'Test throwing an error if the API prefix starts with /healthz/'
     with pytest.raises(ValueError):
         MyApplication("/healthz/", 'sqlite:////tmp/ngshare.db', '/tmp/ngshare/')
+
 
 @pytest.mark.gen_test
 def test_home(http_client, base_url):

--- a/ngshare/test_ngshare.py
+++ b/ngshare/test_ngshare.py
@@ -76,6 +76,18 @@ def assert_success(url, data=None, params=None, method='GET'):
     assert resp['success'] == True
     return resp
 
+@pytest.mark.gen_test
+def test_health(http_client, base_url):
+    'Test /healthz endpoint'
+    response = yield http_client.fetch(base_url + '/healthz')
+    assert response.code == 200
+    assert json.loads(response.body)['success']
+
+@pytest.mark.gen_test
+def test_api_endpoint_conflict(http_client, base_url):
+    'Test throwing an error if the API prefix starts with /healthz/'
+    with pytest.raises(ValueError):
+        MyApplication("/healthz/", 'sqlite:////tmp/ngshare.db', '/tmp/ngshare/')
 
 @pytest.mark.gen_test
 def test_home(http_client, base_url):


### PR DESCRIPTION
Add /healthz to ngshare as a health endpoint that k8s can use to make sure ngshare is alive and well